### PR TITLE
Add ability hash all assets output by webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,13 @@ abcd123 -> the latest Git hash
 filename-chunk\.(?!abcd123)\w{7}\.min\.js/ -> the default regex
 filename-chunk.1234abc.min.js -> this would be deleted
 ```
-If the default regex isn't working for you, you can initialize the `regex` array option with an additional `new RegExp()` via `regex: [new RegExp('/your-regex/')]`. Note that there's not (yet) a way to dynamically skip the current Git hash (the `(?!abcd123)` part in the example). So if you use this option, you'll need to use the `skipHash` option also. Also note that your specified regex will not override the built-in regex logic, but simply add to it.
+If the default regex isn't working for you, you can initialize the `regex` array option with an additional `new RegExp()` via:
+```
+regex: {
+	myregex: new RegExp('/my-regex/')
+}
+```
+The property name you use for your custom regex can be arbitrary, as it is only necessary to ensure we don't build any regex more than once while the plugin is processing. Note that there's not (yet) a way to dynamically skip the current Git hash (the `(?!abcd123)` part in the example). So if you use this option, you'll need to use the `skipHash` option also. Also note that your specified regex will not override the built-in regex logic, it will simply add to it.
 
 ## Post-compilation updates
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ module.exports = {
 You can pass these options when you instantiate the plugin in your `plugins` array:
 
 #### `placeholder`
-Defaults to `[githash]`. Pass another string to use as the placeholder in filenames.
+
+Defaults to `"[githash]"`. Pass another string, including surrounding brackets, to use as the placeholder in filenames.
 
 #### `cleanup`
+
 Defaults to `false`. Pass `true` to delete old versions after Webpack is finished. This works by searching for files in the output directory that match the same pattern as the files that were just compiled, except for the hash. Note the the number of characters in the hash must match. For example:
 
 ```
@@ -45,6 +47,7 @@ bundle.987aas880m.js -> would *NOT* be deleted
 ```
 
 #### `callback`
+
 Optional callback function that runs on Webpack's `done` [step](https://webpack.github.io/docs/plugins.html#done). It receives three arguments:
 
 1. `hash` The hash used as the latest version by the plugin (_not_ Webpack's `[hash]`).
@@ -53,7 +56,7 @@ Optional callback function that runs on Webpack's `done` [step](https://webpack.
 
 #### `skipHash`
 
-Defaults to hash of most recent Git commit on the current branch. This is the unique string that will be used as the version identifier, and will be "skipped" if the plugin is set to delete old versions when Webpack is finished. See `cleanup` above.
+This is the unique string that will be used as the version identifier, and will be "skipped" if the plugin is set to delete old versions when Webpack is finished. Defaults to hash of most recent Git commit on the current branch. See `cleanup` above.
 
 #### `hashLength`
 
@@ -82,7 +85,7 @@ The property name you use for your custom regex can be arbitrary, as it is only 
 
 ## Post-compilation updates
 
-Here's a simple example of how to use the `callback` option to edit a `<script>` tag to load the load the latest versionof a file.
+Here's a simple example of how to use the `callback` option to edit a `<script>` tag for the latest version hash.
 
 ```
 module.exports = {
@@ -90,8 +93,13 @@ module.exports = {
 		new WebpackGitHash({
 			cleanup: true,
 			callback: function(versionHash) {
+				// get contents of index.html
 				var indexHtml = fs.readFileSync('./index.html', 'utf8');
+
+				// replace app-bundle.{old version}.js with app-bundle.{new version}.js in src attribute
 				indexHtml = indexHtml.replace(/src="\/static\/app-bundle\.\w+\.js/, 'src="/static/app-bundle.' + versionHash + '.js');
+
+				// update contents of index.html
 				fs.writeFileSync('./index.html', indexHtml);
 			}
 		})

--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ Defaults to `output.path` in your Webpack config. You can change that here thoug
 
 #### `regex`
 
-If you use the `cleanup` option to delete old verions, the plugin attempts to create regular expressions to match the filenames, based on the original Webpack config. For instance:
+If you use the `cleanup` option to delete old verions, the plugin attempts to create regular expressions to match the filenames, based on assets Webpack is generating that include the configured placeholder. This will happen after all other placeholders have been replaced. For instance:
 ```
-[name]-chunk.[githash].min.js -> the config's output.chunkFilename
+filename-chunk.[githash].min.js -> the config's output.chunkFilename
 abcd123 -> the latest Git hash
-/\w+-chunk\.(?!abcd123)\w{7}\.min\.js/ -> the default regex
-global-chunk.1234abc.min.js -> this would be deleted
+filename-chunk\.(?!abcd123)\w{7}\.min\.js/ -> the default regex
+filename-chunk.1234abc.min.js -> this would be deleted
 ```
-If the default regex isn't working for you, you can specify a new `RegExp` in `regex.filename` and/or `regex.chunkFilename`. Note that there's not (yet) a way to dynamically skip the current Git hash (the `(?!abcd123)` part in the example). So if you use this option, you'll need to use the `skipHash` option also.
+If the default regex isn't working for you, you can initialize the `regex` array option with an additional `new RegExp()` via `regex: [new RegExp('/your-regex/')]`. Note that there's not (yet) a way to dynamically skip the current Git hash (the `(?!abcd123)` part in the example). So if you use this option, you'll need to use the `skipHash` option also. Also note that your specified regex will not override the built-in regex logic, but simply add to it.
 
 ## Post-compilation updates
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * Webpack plugin for versioning bundles and chunks with the hash of the last Git commit
  */
 
-var fs = require('fs');
+var fs = require('fs-extra');
 var path = require('path');
 var child_process = require('child_process');
 
@@ -12,8 +12,8 @@ var child_process = require('child_process');
 function WebpackGitHash(opts) {
   // Bind methods that need it
   this.doPlaceholder = this.doPlaceholder.bind(this);
-  this.cleanupFiles = this.cleanupFiles.bind(this);
-  this.loopFiles = this.loopFiles.bind(this);
+  // this.cleanupFiles = this.cleanupFiles.bind(this);
+  this.populateRegex = this.populateRegex.bind(this);
   this.deleteObsoleteFile = this.deleteObsoleteFile.bind(this);
   this.loopAssets = this.loopAssets.bind(this);
 
@@ -61,25 +61,26 @@ function WebpackGitHash(opts) {
 /**
  * Test if a file can be deleted, then delete it
  */
-WebpackGitHash.prototype.deleteObsoleteFile = function(filename) {
-  if ((this.regex.filename && this.regex.filename.test(filename)) ||
-    (this.regex.chunkFilename && this.regex.chunkFilename.test(filename))) {
-    // delete synchronously so we know when loopFiles() is complete
-    fs.unlinkSync(path.join(this.outputPath, filename));
-    console.log('WebpackGitHash: Deleted ' + filename);
-    this.deletedFiles.push(filename);
-  }
+WebpackGitHash.prototype.deleteObsoleteFile = function(file) {
+  Object.keys(this.regex).forEach(function(assetName) {
+    var testPath = file.path.replace(this.outputPath + '/', '');
+
+    if (this.regex[assetName].test(testPath)) {
+      fs.unlink(file.path, function(err) {
+        if (err) {
+          console.log(err);
+        }
+        console.log('WebpackGitHash: Deleted ' + file.path);
+      });
+      this.deletedFiles.push(file.path);
+    }
+  }.bind(this));
 }
 
-/**
- * Loop through files after reading folder contents
- */
-WebpackGitHash.prototype.loopFiles = function(err, contents) {
-  if (err) {
-    throw err;
+WebpackGitHash.prototype.populateRegex = function(assetName) {
+  if (!this.regex.hasOwnProperty(assetName)) {
+    this.regex[assetName] = this.buildRegex(assetName, this.skipHash);
   }
-  contents.forEach(this.deleteObsoleteFile);
-  this.doCallback();
 }
 
 /**
@@ -94,18 +95,6 @@ WebpackGitHash.prototype.doCallback = function(stats) {
 }
 
 /**
- * Delete static chunk JS files containing a hash other than the one we want to skip
- */
-WebpackGitHash.prototype.cleanupFiles = function(stats) {
-  console.log('WebpackGitHash: Cleaning up Webpack files; skipping ' + this.placeholder + ': ' + this.skipHash);
-  // Save Webpack stats for later
-  if (stats) {
-    this.stats = stats;
-  }
-  fs.readdir(this.outputPath, this.loopFiles);
-}
-
-/**
  * Get hash of last git commit
  */
 WebpackGitHash.prototype.getSkipHash = function(length) {
@@ -117,13 +106,7 @@ WebpackGitHash.prototype.getSkipHash = function(length) {
  * Turn processed filename into regex for later cleanup
  */
 WebpackGitHash.prototype.buildRegex = function(template, hash) {
-  // discard any prepended directories
-  var parts = template.split('/');
-  var regex = parts.pop();
-
-  // Replace Webpack placeholders, e.g.
-  // '[name]-chunk.1234567.min.js' -> '[-_\\w]+-chunk.1234567.min.js'
-  regex = regex.replace(/\[\w+\]/gi, '[-_\\w]+');
+  var regex = template;
 
   // escape dots, e.g.
   // '\\w+-chunk.1234567.js' -> '\\w+-chunk\\.1234567\\.js'
@@ -131,20 +114,20 @@ WebpackGitHash.prototype.buildRegex = function(template, hash) {
 
   // replace hash
   // '\\w+-chunk\\.1234567\\.min\\.js' -> '\\w+-chunk\\.(?!1234567)\\w{7}\\.min\\.js'
-  regex = regex.replace(hash, '(?!' + hash + ')\\w{' + hash.length + '}');
+  regex = regex.replace(this.placeholder, '(?!' + hash + ')\\w{' + hash.length + '}');
 
-  return new RegExp(regex);
+  // String must be at the end of the filename (to prevent sourcemaps from matchin too many regexes)
+  return new RegExp(regex + '$');
 }
 
 /**
  * Attempt to replace the placeholder string in a output string
  */
-WebpackGitHash.prototype.doPlaceholder = function(key, original) {
+WebpackGitHash.prototype.doPlaceholder = function(original) {
   var newString = original.replace(this.placeholder, this.skipHash);
   if (newString === original) {
     return false;
   }
-  this.regex[key] = this.regex[key] || this.buildRegex(newString, this.skipHash);
   return newString;
 }
 
@@ -153,13 +136,22 @@ WebpackGitHash.prototype.doPlaceholder = function(key, original) {
  */
 WebpackGitHash.prototype.loopAssets = function(compilation, callback) {
   Object.keys(compilation.assets).forEach(function(assetName) {
-    var hashedAssetName = this.doPlaceholder('assets', assetName);
+    var hashedAssetName = this.doPlaceholder(assetName);
     if (hashedAssetName) {
       compilation.assets[hashedAssetName] = compilation.assets[assetName];
       delete compilation.assets[assetName];
     }
     console.log('WebpackGitHash: hash added to ' + assetName);
+    this.populateRegex(assetName);
   }.bind(this));
+
+  if (this.cleanup) {
+    console.log('WebpackGitHash: Cleaning up files; skipping hash: ' + this.skipHash);
+    fs.walk(this.outputPath)
+      .on('data', function(file) {
+        this.deleteObsoleteFile(file);
+      }.bind(this));
+  }
   callback();
 }
 
@@ -173,13 +165,7 @@ WebpackGitHash.prototype.apply = function(compiler) {
   }
 
   compiler.plugin('emit', this.loopAssets);
-
-  if (this.cleanup === true &&
-    (this.updated.filename || this.updated.chunkFilename)) {
-    compiler.plugin('done', this.cleanupFiles);
-  } else {
-    compiler.plugin('done', this.doCallback);
-  }
+  compiler.plugin('done', this.doCallback);
 }
 
 module.exports = WebpackGitHash;

--- a/index.js
+++ b/index.js
@@ -133,9 +133,8 @@ WebpackGitHash.prototype.replaceAsset = function(compilation, assetName) {
  */
 WebpackGitHash.prototype.doCallback = function(stats) {
   // Webpack stats passed directly, or stored earlier, or null
-  stats = stats || this.stats;
   if (typeof this.callback === 'function') {
-    this.callback(this.skipHash, this.deletedFiles, stats);
+    this.callback(this.skipHash, this.deletedFiles, stats || this.stats);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -107,6 +107,18 @@ WebpackGitHash.prototype.cleanupFiles = function() {
 WebpackGitHash.prototype.replaceAsset = function(compilation, assetName) {
   var hashedAssetName = this.doPlaceholder(assetName);
 
+  for (var i = 0; i < compilation.chunks.length; i++) {
+    var chunk = compilation.chunks[i];
+
+    for (var j = 0; j < chunk.files.length; j++) {
+      var file = chunk.files[j];
+
+      if (assetName === file) {
+        compilation.chunks[i].files[j] = hashedAssetName;
+      }
+    };
+  };
+
   if (hashedAssetName) {
     compilation.assets[hashedAssetName] = compilation.assets[assetName];
     delete compilation.assets[assetName];

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function WebpackGitHash(opts) {
   this.outputPath = opts.outputPath || null;
 
   // Pre-specify regexes for filename and chunkFilename
-  this.regex = opts.regex || [];
+  this.regex = opts.regex || {};
 
   // Optional callback function that receives the hash and list of deleted files
   this.callback = opts.callback || null;
@@ -63,8 +63,10 @@ function WebpackGitHash(opts) {
  * Test if a file can be deleted, then delete it
  */
 WebpackGitHash.prototype.deleteObsoleteFile = function(file) {
-  for (var i = 0; i < this.regex.length; i++) {
-    var currentRegex = this.regex[i];
+  var regexKeys = Object.keys(this.regex);
+
+  for (var i = 0; i < regexKeys.length; i++) {
+    var currentRegex = this.regex[regexKeys[i]];
     var testPath = file.path.replace(this.outputPath, '');
 
     if (currentRegex.test(testPath)) {
@@ -84,7 +86,7 @@ WebpackGitHash.prototype.deleteObsoleteFile = function(file) {
  */
 WebpackGitHash.prototype.populateRegex = function(assetName) {
   if (!this.regex.hasOwnProperty(assetName)) {
-    this.regex = this.regex.concat(this.buildRegex(assetName, this.skipHash));
+    this.regex[assetName] = this.buildRegex(assetName, this.skipHash);
   }
 }
 
@@ -173,7 +175,7 @@ WebpackGitHash.prototype.loopAssets = function(compilation, callback) {
   var assetNames = Object.keys(compilation.assets);
 
   for (var i = 0; i < assetNames.length; i++) {
-    this.replaceAsset(compilation, compilation.assets[assetName[i]]);
+    this.replaceAsset(compilation, assetNames[i]);
   }
 
   if (this.cleanup) {

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ WebpackGitHash.prototype.deleteObsoleteFile = function(file) {
  */
 WebpackGitHash.prototype.populateRegex = function(assetName) {
   // Sourcemap extension is included in regex
-  assetName = assetName.replace('.map', '');
+  assetName = assetName.replace(/\.map$/, '');
 
   // Add regex only if it doesn't already exist in cache
   if (!this.regex.hasOwnProperty(assetName)) {
@@ -126,6 +126,8 @@ WebpackGitHash.prototype.replaceAsset = function(compilation, assetName) {
     console.log('WebpackGitHash: hash added to ' + assetName);
 
     this.populateRegex(assetName);
+  } else {
+    console.log('WebpackGitHash: skipped ' + assetName);
   }
 }
 
@@ -162,7 +164,7 @@ WebpackGitHash.prototype.buildRegex = function(template, hash) {
   regex = regex.replace(this.placeholder, '(?!' + hash + ')\\w{' + hash.length + '}');
 
   // remove sourcemap extension, use in regex instead
-  regex = regex.replace('.map', '');
+  regex = regex.replace(/\.map$/, '');
   regex = regex + '(\\.map)?$';
 
   // Add optional forward slash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-git-hash",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Webpack plugin for versioning bundles and chunks with the hash of the last Git commit",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://github.com/alleyinteractive/webpack-git-hash#readme",
   "devDependencies": {
-    "mocha": "3.0.2",
     "chai": "3.5.0",
-    "rimraf": "2.5.4"
+    "fs-extra": "^0.30.0",
+    "mocha": "3.0.2"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -65,9 +65,9 @@ describe('webpack-git-hash test suite', function() {
 
     // Cleanup files and test the result
     var replacedFilename = test.replaceAsset(compilation, filename);
-    expect(test.regex.length).to.equal(1);
-    expect(test.regex[0].test(filename)).to.equal(false);
-    expect(test.regex[0].test(oldFilename)).to.equal(true);
+    expect(test.regex).to.have.property(filename);
+    expect(test.regex[filename].test(filename)).to.equal(false);
+    expect(test.regex[filename].test(oldFilename)).to.equal(true);
     expect(compilation.assets).to.have.property('file.abcdefg.min.js').and.to.equal('test');
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -3,9 +3,8 @@
  */
 
 var expect = require('chai').expect;
-var fs = require('fs');
+var fs = require('fs-extra');
 var path = require('path');
-var rimraf = require('rimraf');
 var WebPackGitHash = require('../');
 
 describe('webpack-git-hash test suite', function() {
@@ -17,7 +16,7 @@ describe('webpack-git-hash test suite', function() {
   });
 
   after(function() {
-    rimraf.sync(testTmpDir);
+    fs.removeSync(testTmpDir);
   });
 
   it('should be a function', function() {
@@ -49,13 +48,31 @@ describe('webpack-git-hash test suite', function() {
     expect(callbackResult).to.equal('1234');
   });
 
-  it('should cleanup files not matching the supplied hash', function() {
-    // Create some dummy files
-    ['abcdefg', 'hijklmn', '1234567', '890wxyz'].forEach(function(hash) {
-      var filename = 'file-' + hash + '.min.js';
-      fs.writeFileSync(path.join(testTmpDir, filename), 'temp file', 'utf8');
+  it('replace placeholder with hash and generate regex', function() {
+    // Set up webpack-git-hash
+    var test = new WebPackGitHash({
+      skipHash: 'abcdefg',
+      cleanup: true,
+      outputPath: testTmpDir,
     });
+    var filename = 'file.' + test.placeholder + '.min.js';
+    var oldFilename = 'file.1234567.min.js';
+    var compilation = {
+      assets: {}
+    }
 
+    compilation.assets[filename] = 'test';
+
+    // Cleanup files and test the result
+    var replacedFilename = test.replaceAsset(compilation, filename);
+    expect(test.regex.length).to.equal(1);
+    expect(test.regex[0].test(filename)).to.equal(false);
+    expect(test.regex[0].test(oldFilename)).to.equal(true);
+    expect(compilation.assets).to.have.property('file.abcdefg.min.js').and.to.equal('test');
+  });
+
+  it('should cleanup files not matching the supplied hash', function() {
+    var filenames = [];
     // Set up webpack-git-hash
     var test = new WebPackGitHash({
       skipHash: 'abcdefg',
@@ -64,6 +81,13 @@ describe('webpack-git-hash test suite', function() {
       regex: {
         filename: /file-(?!abcdefg)\w{7}\.min\.js/
       }
+    });
+
+    // Create some dummy files
+    ['abcdefg', 'hijklmn', '1234567', '890wxyz'].forEach(function(hash) {
+      var filename = 'file-' + hash + '.min.js';
+      filenames.push(filename);
+      fs.writeFileSync(path.join(testTmpDir, filename), 'temp file', 'utf8');
     });
 
     // Cleanup files and test the result
@@ -83,23 +107,29 @@ describe('webpack-git-hash test suite', function() {
 
   it('should call the callback function', function() {
     var testVar = 0;
-    function testCallback() {
+    var testCallback = function() {
       testVar++;
     };
+    // Create tester and trigger the callback
+    var test = new WebPackGitHash({
+      callback: testCallback
+    });
+    // Compiler
     var mockCompiler = {
       options: {
         output: false
       },
+      assets: {
+        'filename.min.js': 'test',
+      },
       plugin: function(evt, callback) {
-        callback();
+        if ('done' === evt) {
+          callback();
+        }
       }
     };
 
-    // Create tester and trigger the callback
-    var testCleanup = new WebPackGitHash({
-      callback: testCallback
-    });
-    testCleanup.apply(mockCompiler);
+    test.apply(mockCompiler);
     expect(testVar).to.equal(1);
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -58,8 +58,11 @@ describe('webpack-git-hash test suite', function() {
     var filename = 'file.' + test.placeholder + '.min.js';
     var oldFilename = 'file.1234567.min.js';
     var compilation = {
-      assets: {}
-    }
+      assets: {},
+      chunks: {
+        files: [filename],
+      },
+    };
 
     compilation.assets[filename] = 'test';
 


### PR DESCRIPTION
- Switch from using filename and chunkFilename templates for hash replacement to leveraging compiler events to access the asset files directly.
- Alter surrounding code to support the updated hash replacement logic including updated regex builder, tests
