### PR TITLE
Add cwd option and fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ global-chunk.1234abc.min.js -> this would be deleted
 ```
 If the default regex isn't working for you, you can specify a new `RegExp` in `regex.filename` and/or `regex.chunkFilename`. Note that there's not (yet) a way to dynamically skip the current Git hash (the `(?!abcd123)` part in the example). So if you use this option, you'll need to use the `skipHash` option also.
 
+#### `cwd`
+
+Directory where the git command is executed. Not all the systems allow to execute git in an inner folder, using this option, this issue is avoided.
+
 ## Post-compilation updates
 
 Here's a simple example of how to use the `callback` option to edit a `<script>` tag to load the load the latest versionof a file.

--- a/index.js
+++ b/index.js
@@ -29,6 +29,9 @@ function WebpackGitHash(opts) {
     this.doCallback = this.doCallback.bind(this);
   }
 
+  // Optional cwd to execute git command
+  this.cwd = opts.cwd || null;
+
   // Can specify a specific hash/version
   if (opts.skipHash) {
     this.skipHash = opts.skipHash;
@@ -108,7 +111,10 @@ WebpackGitHash.prototype.cleanupFiles = function(stats) {
  * Get hash of last git commit
  */
 WebpackGitHash.prototype.getSkipHash = function(length) {
-  var skipHash = child_process.execSync('git rev-parse --short=' + length + ' HEAD', { encoding: 'utf8' });
+  var skipHash = child_process.execSync('git rev-parse --short=' + length + ' HEAD', {
+    encoding: 'utf8',
+    cwd: this.cwd
+  });
   return skipHash.trim();
 }
 

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ WebpackGitHash.prototype.cleanupFiles = function(stats) {
  * Get hash of last git commit
  */
 WebpackGitHash.prototype.getSkipHash = function(length) {
-  var skipHash = child_process.execSync('git rev-parse --short=' + length + ' HEAD', {
+  var skipHash = child_process.execSync('git describe --always --abbrev=' + length, {
     encoding: 'utf8',
     cwd: this.cwd
   });

--- a/test/test.js
+++ b/test/test.js
@@ -30,6 +30,7 @@ describe('webpack-git-hash test suite', function() {
     expect(test.cleanup).to.equal(false);
     expect(test.hashLength).to.equal(test.skipHash.length);
     expect(test.hashLength).to.equal(7);
+    expect(test.cwd).to.equal(null);
   });
 
   it('should set up custom options correctly', function() {
@@ -38,18 +39,20 @@ describe('webpack-git-hash test suite', function() {
       placeholder: '[custom]',
       cleanup: true,
       skipHash: '1234',
-      callback: function(hash) { callbackResult = hash; }
+      callback: function(hash) { callbackResult = hash; },
+      cwd: '../..'
     });
     expect(test.placeholder).to.equal('[custom]');
     expect(test.cleanup).to.equal(true);
     expect(test.skipHash).to.equal('1234');
     expect(test.hashLength).to.equal(test.skipHash.length);
     expect(test.hashLength).to.equal(4);
+    expect(test.cwd).to.equal('../..');
     test.doCallback()
     expect(callbackResult).to.equal('1234');
   });
 
-  it('should cleanup files not matching the supplied hash', function() {
+  it('should cleanup files not matching the supplied hash', function(done) {
     // Create some dummy files
     ['abcdefg', 'hijklmn', '1234567', '890wxyz'].forEach(function(hash) {
       var filename = 'file-' + hash + '.min.js';
@@ -68,16 +71,19 @@ describe('webpack-git-hash test suite', function() {
 
     // Cleanup files and test the result
     test.cleanupFiles();
+
     setTimeout(function() {
       // Only the file that matched the hash should still be there
       testTmpDirContents = fs.readdirSync(testTmpDir);
-      expect(testTmpDirContents.toString()).to.equal('.,..,file-abcdefg.min.js');
+      expect(testTmpDirContents.toString()).to.equal('file-abcdefg.min.js');
 
       // Files not matching the supplied hash should be in deletedFiles
       expect(test.deletedFiles.length).to.equal(3);
-      expect(test.deletedFiles[0]).to.equal('file-hijklmn.min.js');
-      expect(test.deletedFiles[1]).to.equal('file-1234567.min.js');
-      expect(test.deletedFiles[2]).to.equal('file-890wxyz.min.js');
+      expect(test.deletedFiles).to.contain('file-hijklmn.min.js');
+      expect(test.deletedFiles).to.contain('file-1234567.min.js');
+      expect(test.deletedFiles).to.contain('file-890wxyz.min.js');
+
+      done();
     }, 500);
   });
 


### PR DESCRIPTION
Some systems does not allow to execute ``git`` command within an inner folder of the repository.

The solution is to pass the ``cwd`` option to the ``exec`` command to execute ``git`` from the root folder of the project.

I have also fixed the tests, though I have not removed the timeout which is causing the extra delay (500ms).